### PR TITLE
Docker 化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,23 @@
-# FROM openjdk:8u181-jdk-slim-stretch AS build
-FROM openjdk:8u181-jdk-slim-stretch
-
+# Stage 1.
+# clustered-kGenProg をコンパイルし，実行バイナリを生成する
+FROM openjdk:8u181-jdk-slim-stretch AS builder
 WORKDIR /root
-
 COPY . .
-
 RUN ./gradlew installDist
 
-
+# Stage 2.
+# Stage 1 で生成したバイナリを保持する
 FROM openjdk:8u181-jdk-alpine3.8
 
 LABEL description="Executes clustered-kGenProg."
 LABEL maintainer="Hiroyuki Matsuo <h.matsuo.engineer@gmail.com>"
 
 RUN adduser -S kgenprog
-
 USER kgenprog
-
 WORKDIR /home/kgenprog
 
-COPY --from=build /root/node/build/install/node .
+COPY --from=builder /root/node/build/install/node .
 
 EXPOSE 50051
+
+CMD ["./bin/kGenProg-coordinator"]


### PR DESCRIPTION
Resolves #10.
ビルド後のイメージサイズは 163 MB です．

```sh
# 1. ビルド
$ cd /path/to/clustered-kGenProg
$ docker build -t clustered-kgenprog .

# 2. coordinator 起動
$ docker run -it --rm -p 50051:50051 clustered-kgenprog

# 3. client 起動（別の端末で）
$ ./kGenProg-client --config /path/to/example/CloseToZero01/kgenprog.toml
```