### PR TITLE
コーディネータ、ワーカー間プロトコルの定義

### DIFF
--- a/node/src/main/proto/kgenprog.proto
+++ b/node/src/main/proto/kgenprog.proto
@@ -39,6 +39,11 @@ service WorkerService {
    * テストを実行する
    */
   rpc executeTest (GrpcExecuteTestRequest) returns (GrpcExecuteTestResponse) {}
+
+  /*
+   * ワーカーからプロジェクトを登録解除する
+   */
+  rpc unregisterProject (GrpcUnregisterProjectRequest) returns (GrpcUnregisterProjectResponse) {}
 }
 
 message GrpcRegisterProjectRequest {


### PR DESCRIPTION
resolve #17 

ミーティングの内容に従って実装
コーディングに入る前にプロトコルについてレビューおねがいします

コーディネータ→ワーカー、ワーカー→コーディネータの2本のコネクションを張る想定

## 通信の流れ
ミーティングから変えたこと：config、project zip は、コーディネータが配るのではなく、ワーカーが取得する
+ どのワーカに配布済みか管理しなくてすむ
+ ワーカーのexecuteTestがステートレスになるので、ロードバランスやk8sによるワーカーの増減がしやすそう

![tmp](https://user-images.githubusercontent.com/2821291/50803796-91f9c780-132e-11e9-94d6-e3a32fefdb9f.png)
